### PR TITLE
Add a "silent" flag to the solve function.

### DIFF
--- a/src/file.jl
+++ b/src/file.jl
@@ -8,9 +8,11 @@ mutable struct POMDPFile <: SARSOPFile
         @assert isfile(filename) "Pomdpx file $(filename) does not exist"
         return new(filename)
     end
-    function POMDPFile(pomdp::POMDP, filename="model.pomdpx")
+    function POMDPFile(pomdp::POMDP, filename="model.pomdpx"; silent=false)
         pomdpx = POMDPXFile(filename)
-        println("Generating a pomdpx file: $(filename)")
+        if silent == false
+            println("Generating a pomdpx file: $(filename)")
+        end
         write(pomdp, pomdpx)
         return new(filename)
     end

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -90,13 +90,21 @@ end
 Runs pomdpsol using the options in 'solver' on 'pomdp',
 and writes out a .policy xml file specified by 'policy'.
 """
-function solve(solver::SARSOPSolver, pomdp::POMDP, policy::POMDPPolicy=create_policy(solver, pomdp))
-    pomdp_file = POMDPFile(pomdp)
+function solve(solver::SARSOPSolver, pomdp::POMDP, policy::POMDPPolicy=create_policy(solver, pomdp); silent=false)
+    pomdp_file = POMDPFile(pomdp, silent=silent)
     if isempty(solver.options)
-        run(`$EXEC_POMDP_SOL $(pomdp_file.filename) --output $(policy.filename)`)
+        if silent == true
+            success(`$EXEC_POMDP_SOL $(pomdp_file.filename) --output $(policy.filename)`)
+        else
+            run(`$EXEC_POMDP_SOL $(pomdp_file.filename) --output $(policy.filename)`)
+        end
     else
         options_list = _get_options_list(solver.options)
-        run(`$EXEC_POMDP_SOL $(pomdp_file.filename) --output $(policy.filename) $options_list`)
+        if silent == true
+            success(`$EXEC_POMDP_SOL $(pomdp_file.filename) --output $(policy.filename) $options_list`)
+        else
+            run(`$EXEC_POMDP_SOL $(pomdp_file.filename) --output $(policy.filename) $options_list`)
+        end
     end
     policy.alphas = POMDPAlphas(policy.filename)
     return policy


### PR DESCRIPTION
For solving issue #13, and allowing iterative tests to run without outputting thousands of lines to STDOUT, I've added a keyword argument `silent` to the `solve()` and `POMDPFile()` functions. It defaults to `false`, meaning that existing code should not be affected in any way.

Calling `solve` with `silent=true`  

```
policy = POMDPs.solve(solver, pomdp, silent=true)
```

now produces no console output, while producing the intended results (`model.pomdpx.`, policy, etc).