### PR TITLE
Changed appl dependency to point to commit e433ee63e542551a7c6d35ec2d…

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -21,41 +21,13 @@ if is_windows()
 end
 
 if is_unix()
-    download("https://github.com/personalrobotics/appl/archive/0.96.tar.gz", "appl-0.96.tar.gz")
-    run(`gunzip appl-0.96.tar.gz`)
-    run(`tar -xvf appl-0.96.tar`)
-    rm("appl-0.96.tar")
-    if isfile("appl-0.96.tar")
-        rm("appl-0.96.tar")
+    if ispath("appl")
+        rm("appl", recursive=true)
     end
-    cd("appl-0.96/src")
-
-    #=
-    function replaceLine(filename::AbstractString, linenum::Int, textofline::AbstractString)
-        outfile = open("temp.txt", "w")
-        infile = open(filename)
-        i = 1
-        for line in eachline(infile)
-            if i == linenum
-                write(outfile, textofline)
-                i += 1
-            else
-                write(outfile, line)
-                i += 1
-            end
-        end
-        close(outfile)
-        close(infile)
-        rm(filename)
-        mv("temp.txt", filename)
-    end
-
-    if is_apple()
-        cd("MathLib")
-        replaceLine("SparseMatrix.h", 24, "            inline SparseCol() {}\n")
-        replaceLine("SparseVector.cpp", 491, "        //printf(\"Iter: %X\\n\", iter);\n")
-        cd("../")
-    end
-    =#
+    # note: v0.96 of appl does not seem to compile properly on some OSX versions
+    run(`git clone https://github.com/personalrobotics/appl/`)
+    cd("appl")
+    run(`git reset --hard e433ee63e542551a7c6d35ec2d71192fd5a06d62`)
+    cd("src")
     run(`make`)
 end

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -1,8 +1,8 @@
-const EXEC_POMDP_SOL = Pkg.dir("SARSOP", "deps", "appl-0.96", "src", "pomdpsol")
-const EXEC_POMDP_SIM = Pkg.dir("SARSOP", "deps", "appl-0.96", "src", "pomdpsim")
-const EXEC_POMDP_EVAL = Pkg.dir("SARSOP", "deps", "appl-0.96", "src", "pomdpeval")
-const EXEC_POLICY_GRAPH_GENERATOR = Pkg.dir("SARSOP", "deps", "appl-0.96", "src", "polgraph")
-const EXEC_POMDP_CONVERT = Pkg.dir("SARSOP", "deps", "appl-0.96", "src", "pomdpconvert")
+const EXEC_POMDP_SOL = Pkg.dir("SARSOP", "deps", "appl", "src", "pomdpsol")
+const EXEC_POMDP_SIM = Pkg.dir("SARSOP", "deps", "appl", "src", "pomdpsim")
+const EXEC_POMDP_EVAL = Pkg.dir("SARSOP", "deps", "appl", "src", "pomdpeval")
+const EXEC_POLICY_GRAPH_GENERATOR = Pkg.dir("SARSOP", "deps", "appl", "src", "polgraph")
+const EXEC_POMDP_CONVERT = Pkg.dir("SARSOP", "deps", "appl", "src", "pomdpconvert")
 
 const DEFAULT_PRECISION = 1e-3
 const DEFAULT_TRIAL_IMPROVEMENT_FACTOR = 0.5

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using POMDPModels
 using Base.Test
 
 # Test SARSOP internals
-pomdp_file = POMDPFile(Pkg.dir("SARSOP", "deps", "appl-0.96", "examples", "POMDPX", "Tiger.pomdpx"))
+pomdp_file = POMDPFile(Pkg.dir("SARSOP", "deps", "appl", "examples", "POMDPX", "Tiger.pomdpx"))
 solver = SARSOPSolver()
 
 # Test simple interface
@@ -19,7 +19,7 @@ evaluate(evaluator, pomdp_file, policy)
 graphgen = PolicyGraphGenerator("Tiger.dot")
 polgraph(graphgen, pomdp_file, policy)
 
-to_pomdpx(POMDPFile(Pkg.dir("SARSOP", "deps", "appl-0.96", "examples", "POMDP", "Tiger.pomdp")))
+to_pomdpx(POMDPFile(Pkg.dir("SARSOP", "deps", "appl", "examples", "POMDP", "Tiger.pomdp")))
 
 up = updater(policy)
 d = initial_state_distribution(pomdp)


### PR DESCRIPTION
Changed appl dependency to point to commit e433ee63e542551a7c6d35ec2d71192fd5a06d62 instead of v0.96 v0.96 seemed to not compile properly on some versions of OSX
v0.96 seemed to not compile properly on some versions of OSX
This is now stored in a folder called appl (instead of appl-0.96)
Made modifications to depts/build.jl, test/runtests.jl and src/constants.jl to reflect change.