### PR TITLE
Updates to run() syntax

### DIFF
--- a/src/graph.jl
+++ b/src/graph.jl
@@ -48,7 +48,5 @@ Generate a policy graph, see PolicyGraphGenerator to see the available options.
 """
 function generate_graph(graphgen::PolicyGraphGenerator)
     options_list = get_graph_generator_options(graphgen)
-    polgraph() do polgraph_path 
-        run(`$polgraph_path $(graphgen.pomdp_filename) --policy-file $(graphgen.policy_filename) $options_list`)
-    end
+    run(`$(polgraph()) $(graphgen.pomdp_filename) --policy-file $(graphgen.policy_filename) $options_list`)
 end

--- a/src/simulator.jl
+++ b/src/simulator.jl
@@ -45,9 +45,7 @@ Simulate a SARSOP policy according to the config specified by `sim::SARSOPSimula
 """
 function POMDPs.simulate(sim::SARSOPSimulator)
     options_list = get_simulator_options(sim)
-    pomdpsim() do pomdpsim_path
-        run(`$pomdpsim_path $(sim.pomdp_filename) --policy-file $(sim.policy_filename) $options_list`)
-    end
+    run(`$(pomdpsim()) $(sim.pomdp_filename) --policy-file $(sim.policy_filename) $options_list`)
 end
 
 """
@@ -104,7 +102,5 @@ simulate a SARSOP policy according to the configuration specified by `ev::SARSOP
 """
 function evaluate(ev::SARSOPEvaluator)
     options_list = get_evaluator_options(ev)
-    pomdpeval() do pomdpeval_path
-        run(`$pomdpeval_path $(ev.pomdp_filename) --policy-file $(ev.policy_filename) $options_list`)
-    end
+    run(`$(pomdpeval()) $(ev.pomdp_filename) --policy-file $(ev.policy_filename) $options_list`)
 end

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -64,12 +64,10 @@ function POMDPs.solve(solver::SARSOPSolver, pomdp::POMDP; kwargs...)
     end
     pomdp_file = POMDPFile(pomdp, solver.pomdp_filename, verbose=solver.verbose)
     options = get_solver_options(solver)
-    pomdpsol() do pomdpsol_path
-        if solver.verbose 
-            run(`$pomdpsol_path $(pomdp_file.filename) --output $(solver.policy_filename) $options`)
-        else
-            success(`$pomdpsol_path $(pomdp_file.filename) --output $(solver.policy_filename) $options`)
-        end
+    if solver.verbose
+        run(`$(pomdpsol()) $(pomdp_file.filename) --output $(solver.policy_filename) $options`)
+    else
+        success(`$(pomdpsol()) $(pomdp_file.filename) --output $(solver.policy_filename) $options`)
     end
     alphas = POMDPAlphas(solver.policy_filename)
     action_map = broadcast(x -> getindex(ordered_actions(pomdp), x), alphas.alpha_actions .+ 1)
@@ -103,9 +101,7 @@ Convert a .pomdp file to a .pomdpx file.
 """
 function to_pomdpx(pomdp::POMDPFile)
     @assert(splitext(pomdp.filename)[2] == ".pomdp")
-    pomdpconvert() do pomdpconvert_path
-        run(`$pomdpconvert_path $(pomdp.filename)`)
-    end
+    run(`$(pomdpconvert()) $(pomdp.filename)`)
 end
 
 mdp_error() = error("SARSOP is designed to solve POMDPs and is not set up to solve MDPs; consider using DiscreteValueIteration.jl to solve MDPs.")


### PR DESCRIPTION
Update run() syntax to be threadsafe. See [here](https://discourse.julialang.org/t/ioerror-could-not-spawn-argument-list-too-long/43728/21)